### PR TITLE
pr/SOFTWARE 5466.grid mapfile

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -345,6 +345,33 @@ def authfile_public():
     return _get_cache_authfile(public_only=True)
 
 
+@app.route("/cache/grid-mapfile")
+@support_cors
+def cache_grid_mapfile():
+    assert stashcache
+    fqdn = request.args.get("fqdn")
+    if not fqdn:
+        return Response("FQDN of cache server required in the 'fqdn' argument", status=400)
+    try:
+        return Response(stashcache.generate_cache_grid_mapfile(global_data, fqdn, suppress_errors=False),
+                        mimetype="text/plain")
+    except ResourceNotRegistered as e:
+        return Response("# {}\n"
+                        "# Please check your query or contact help@opensciencegrid.org\n"
+                        .format(e),
+                        mimetype="text/plain", status=404)
+    except DataError as e:
+        app.logger.error("{}: {}".format(request.full_path, e))
+        return Response("# Error generating grid-mapfile for this FQDN:\n"
+                        "# {}\n"
+                        "# Please check configuration in OSG topology or contact help@opensciencegrid.org\n"
+                        .format(e),
+                        mimetype="text/plain", status=400)
+    except Exception:
+        app.log_exception(sys.exc_info())
+        return Response("Server error getting grid-mapfile, please contact help@opensciencegrid.org", status=503)
+
+
 @app.route("/origin/Authfile")
 @app.route("/stashcache/origin-authfile")
 def origin_authfile():
@@ -355,6 +382,33 @@ def origin_authfile():
 @app.route("/stashcache/origin-authfile-public")
 def origin_authfile_public():
     return _get_origin_authfile(public_only=True)
+
+
+@app.route("/origin/grid-mapfile")
+@support_cors
+def origin_grid_mapfile():
+    assert stashcache
+    fqdn = request.args.get("fqdn")
+    if not fqdn:
+        return Response("FQDN of origin server required in the 'fqdn' argument", status=400)
+    try:
+        return Response(stashcache.generate_origin_grid_mapfile(global_data, fqdn, suppress_errors=False),
+                        mimetype="text/plain")
+    except ResourceNotRegistered as e:
+        return Response("# {}\n"
+                        "# Please check your query or contact help@opensciencegrid.org\n"
+                        .format(e),
+                        mimetype="text/plain", status=404)
+    except DataError as e:
+        app.logger.error("{}: {}".format(request.full_path, e))
+        return Response("# Error generating grid-mapfile for this FQDN:\n"
+                        "# {}\n"
+                        "# Please check configuration in OSG topology or contact help@opensciencegrid.org\n"
+                        .format(e),
+                        mimetype="text/plain", status=400)
+    except Exception:
+        app.log_exception(sys.exc_info())
+        return Response("Server error getting grid-mapfile, please contact help@opensciencegrid.org", status=503)
 
 
 @app.route("/stashcache/scitokens")

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -286,7 +286,7 @@ class _IdNamespaceData:
         self.public_paths = set()
         self.id_to_paths = defaultdict(set)
         self.id_to_str = {}
-        self.dn_to_dn_hash = {}
+        self.grid_mapfile_lines = set()
         self.warnings = []
 
     @classmethod
@@ -333,10 +333,8 @@ class _IdNamespaceData:
                     if authz.used_in_authfile:
                         me.id_to_paths[authz.get_authfile_id()].add(path)
                         me.id_to_str[authz.get_authfile_id()] = str(authz)
-                        try:
-                            me.dn_to_dn_hash[authz.dn] = authz.get_dn_hash()
-                        except AttributeError:  # this authz type doesn't have a DN
-                            pass
+                    if authz.used_in_grid_mapfile:
+                        me.grid_mapfile_lines.add(authz.get_grid_mapfile_line())
         return me
 
 
@@ -395,7 +393,7 @@ def generate_origin_grid_mapfile(global_data: GlobalData, fqdn: str, suppress_er
 
     grid_mapfile_lines = []
     grid_mapfile_lines.extend(idns.warnings)
-    grid_mapfile_lines.extend(f'"{dn}" {dn_hash}' for dn, dn_hash in idns.dn_to_dn_hash.items())
+    grid_mapfile_lines.extend(sorted(idns.grid_mapfile_lines))
 
     return "\n".join(grid_mapfile_lines) + "\n"
 

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -292,7 +292,7 @@ class _IdNamespaceData:
     @classmethod
     def for_origin(cls, topology: Topology, vos_data: VOsData, origin_resource: Optional[Resource],
                    public_origin: bool) -> "_IdNamespaceData":
-        me = cls()
+        self = cls()
         for vo_name, stashcache_obj in vos_data.stashcache_by_vo_name.items():
             for path, namespace in stashcache_obj.namespaces.items():
                 if not namespace_allows_origin_resource(namespace, origin_resource):
@@ -300,7 +300,7 @@ class _IdNamespaceData:
                 if not resource_allows_namespace(origin_resource, namespace):
                     continue
                 if namespace.is_public():
-                    me.public_paths.add(path)
+                    self.public_paths.add(path)
                     continue
                 if public_origin:
                     continue
@@ -316,14 +316,14 @@ class _IdNamespaceData:
                     allowed_resources.extend(allowed_caches)
                 else:
                     # TODO This situation should be caught by the CI
-                    me.warnings.append(f"# WARNING: No working cache / namespace combinations found for {path}")
+                    self.warnings.append(f"# WARNING: No working cache / namespace combinations found for {path}")
 
                 for resource in allowed_resources:
                     dn = resource.data.get("DN")
                     if dn:
                         authz_list.append(DNAuth(dn))
                     else:
-                        me.warnings.append(
+                        self.warnings.append(
                             f"# WARNING: Resource {resource.name} was skipped for VO {vo_name}, namespace {path}"
                             f" because the resource does not provide a DN."
                         )
@@ -331,11 +331,11 @@ class _IdNamespaceData:
 
                 for authz in authz_list:
                     if authz.used_in_authfile:
-                        me.id_to_paths[authz.get_authfile_id()].add(path)
-                        me.id_to_str[authz.get_authfile_id()] = str(authz)
+                        self.id_to_paths[authz.get_authfile_id()].add(path)
+                        self.id_to_str[authz.get_authfile_id()] = str(authz)
                     if authz.used_in_grid_mapfile:
-                        me.grid_mapfile_lines.add(authz.get_grid_mapfile_line())
-        return me
+                        self.grid_mapfile_lines.add(authz.get_grid_mapfile_line())
+        return self
 
 
 def generate_origin_authfile(global_data: GlobalData, fqdn: str, suppress_errors=True, public_origin=False) -> str:

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -218,9 +218,88 @@ class TestAPI:
                 for cache in namespace["caches"]:
                     validate_cache_schema(cache)
 
+    def test_origin_grid_mapfile(self, client: flask.Flask):
+        TEST_ORIGIN = "origin-auth2001.chtc.wisc.edu"  # This origin serves protected data
+        response = client.get("/origin/grid-mapfile")
+        assert response.status_code == 400  # fqdn not specified
+
+        # Compare the hashes in an origin's grid-mapfile with the hashes in the origin's Authfile
+
+        # First get a set of the hashes in the grid-mapfile
+        response = client.get(f"/origin/grid-mapfile?fqdn={TEST_ORIGIN}")
+        assert response.status_code == 200
+        grid_mapfile_text = response.data.decode("utf-8")
+        grid_mapfile_lines = grid_mapfile_text.split("\n")
+        # Have a reasonable number of mappings
+        assert len(grid_mapfile_lines) > 20
+
+        mapfile_matches = filter(None,
+                                 (re.fullmatch(r'"[^"]+" ([0-9a-f]+[.]0)', line)
+                                  for line in grid_mapfile_lines))
+        mapfile_hashes = set(match.group(1) for match in mapfile_matches)
+
+        # Next get a set of the user (u) hashes in the authfile
+        response = client.get(f"/origin/Authfile?fqdn={TEST_ORIGIN}")
+        assert response.status_code == 200
+        authfile_text = response.data.decode("utf-8")
+        authfile_lines = authfile_text.split("\n")
+        # Have a reasonable number of caches; each one has a comment with the DN so there should be
+        # twice as many lines as authorizations
+        assert len(authfile_lines) > 40
+
+        authfile_matches = filter(None,
+                                  (re.match(r'u ([0-9a-f]+[.]0)', line)
+                                   for line in authfile_lines))
+        authfile_hashes = set(match.group(1) for match in authfile_matches)
+
+        hashes_not_in_mapfile = authfile_hashes - mapfile_hashes
+        assert not hashes_not_in_mapfile, f"Hashes in authfile but not in mapfile: {hashes_not_in_mapfile}"
+
+        hashes_not_in_authfile = mapfile_hashes - authfile_hashes
+        assert not hashes_not_in_authfile, f"Hashes in mapfile but not in authfile: {hashes_not_in_authfile}"
+
+    def test_cache_grid_mapfile(self, client: flask.Flask):
+        TEST_CACHE = "stash-cache.osg.chtc.io"  # This cache allows cert-based auth but not LIGO data
+        response = client.get("/cache/grid-mapfile")
+        assert response.status_code == 400  # fqdn not specified
+
+        # Compare the hashes in a cache's grid-mapfile with the hashes in the cache's Authfile
+
+        # First get a set of the hashes in the grid-mapfile
+        response = client.get(f"/cache/grid-mapfile?fqdn={TEST_CACHE}")
+        assert response.status_code == 200
+        grid_mapfile_text = response.data.decode("utf-8")
+        grid_mapfile_lines = grid_mapfile_text.split("\n")
+        # Make sure we have some mappings (we may not have LIGO data so there's only a few)
+        assert len(grid_mapfile_lines) > 1
+
+        mapfile_matches = filter(None,
+                                 (re.fullmatch(r'"[^"]+" ([0-9a-f]+[.]0)', line)
+                                  for line in grid_mapfile_lines))
+        mapfile_hashes = set(match.group(1) for match in mapfile_matches)
+
+        # Next get a set of the user (u) hashes in the authfile
+        response = client.get(f"/cache/Authfile?fqdn={TEST_CACHE}")
+        assert response.status_code == 200
+        authfile_text = response.data.decode("utf-8")
+        authfile_lines = authfile_text.split("\n")
+        # Make sure we have some mappings; each one has a comment with the DN so there should be
+        # twice as many lines as authorizations
+        assert len(authfile_lines) > 2
+
+        authfile_matches = filter(None,
+                                  (re.match(r'u ([0-9a-f]+[.]0)', line)
+                                   for line in authfile_lines))
+        authfile_hashes = set(match.group(1) for match in authfile_matches)
+
+        hashes_not_in_mapfile = authfile_hashes - mapfile_hashes
+        assert not hashes_not_in_mapfile, f"Hashes in authfile but not in mapfile: {hashes_not_in_mapfile}"
+
+        hashes_not_in_authfile = mapfile_hashes - authfile_hashes
+        assert not hashes_not_in_authfile, f"Hashes in mapfile but not in authfile: {hashes_not_in_authfile}"
+
 
 class TestEndpointContent:
-
     # Pre-build some test cases based on AMNH resources
     mock_facility = Facility("test_facility_name", 12345)
 

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -52,7 +52,9 @@ TEST_ENDPOINTS = [
     "/origin/Authfile",
     "/origin/Authfile-public",
     "/origin/scitokens.conf",
-    "/cache/scitokens.conf"
+    "/cache/scitokens.conf",
+    "/cache/grid-mapfile",
+    "/origin/grid-mapfile",
 ]
 
 

--- a/src/tests/test_stashcache.py
+++ b/src/tests/test_stashcache.py
@@ -6,6 +6,7 @@ from pytest_mock import MockerFixture
 # Rewrites the path so the app can be imported like it normally is
 import os
 import sys
+
 topdir = os.path.join(os.path.dirname(__file__), "..")
 sys.path.append(topdir)
 
@@ -68,6 +69,16 @@ class TestStashcache:
             else:
                 assert False, 'Unexpected text "%s".\nFull text:\n%s' % (line, test_origin_text)
         assert num_mappings > 5, "Too few mappings found.\nFull text:\n%s" % test_origin_text
+
+    def test_cache_authfile(self, client: flask.Flask):
+        text = stashcache.generate_cache_authfile(
+            global_data,
+            I2_TEST_CACHE,
+            legacy=True,
+            suppress_errors=False,
+        )
+
+        assert False, f"Cache authfile dump:\n{text}"
 
     def test_cache_grid_mapfile(self, client: flask.Flask):
         nohost_text = stashcache.generate_cache_grid_mapfile(global_data, "", legacy=False, suppress_errors=False)

--- a/src/tests/test_stashcache.py
+++ b/src/tests/test_stashcache.py
@@ -17,9 +17,23 @@ GRID_MAPPING_REGEX = re.compile(r'^"(/[^"]*CN=[^"]+")\s+([0-9a-f]{8}[.]0)$')
 # ^^ the DN starts with a slash and will at least have a CN in it.
 EMPTY_LINE_REGEX = re.compile(r'^\s*(#|$)')  # Empty or comment-only lines
 I2_TEST_CACHE = "osg-sunnyvale-stashcache.t2.ucsd.edu"
-
-
 # ^^ one of the Internet2 caches; these serve both public and LIGO data
+
+
+# Some DNs I can use for testing and the hashes they map to.
+# All of these were generated with osg-ca-generator on alma8 and printed with
+#   openssl x509 -in /etc/grid-security/hostcert.pem -noout -subject -subject_hash_old -nameopt compat
+# (trailing ".0" added by hand)
+MOCK_DNS_AND_HASHES = {
+    "/DC=org/DC=opensciencegrid/C=US/O=OSG Software/OU=Services/CN=testhost1": "d460d8b7.0",
+    "/DC=org/DC=opensciencegrid/C=US/O=OSG Software/OU=Services/CN=testhost2": "23c91cd1.0",
+    "/DC=org/DC=opensciencegrid/C=US/O=OSG Software/OU=Services/CN=testhost3": "fd626fa1.0",
+    "/DC=org/DC=opensciencegrid/C=US/O=OSG Software/OU=Services/CN=testhost4": "cc84ae86.0",
+    "/DC=org/DC=opensciencegrid/C=US/O=OSG Software/OU=Services/CN=testhost5": "8967f473.0",
+}
+
+MOCK_DN_LIST = list(MOCK_DNS_AND_HASHES.keys())
+
 
 @pytest.fixture
 def client():
@@ -70,7 +84,8 @@ class TestStashcache:
                 assert False, 'Unexpected text "%s".\nFull text:\n%s' % (line, test_origin_text)
         assert num_mappings > 5, "Too few mappings found.\nFull text:\n%s" % test_origin_text
 
-    def test_cache_authfile(self, client: flask.Flask):
+    def test_cache_authfile(self, client: flask.Flask, mocker: MockerFixture):
+        m = mocker.patch.object(global_data, "get_ligo_dn_list", spec={"return_value": MOCK_DN_LIST})
         text = stashcache.generate_cache_authfile(
             global_data,
             I2_TEST_CACHE,
@@ -80,7 +95,7 @@ class TestStashcache:
 
         assert False, f"Cache authfile dump:\n{text}"
 
-    def test_cache_grid_mapfile(self, client: flask.Flask):
+    def test_cache_grid_mapfile(self, client: flask.Flask, mocker: MockerFixture):
         nohost_text = stashcache.generate_cache_grid_mapfile(global_data, "", legacy=False, suppress_errors=False)
         for line in nohost_text.split("\n"):
             if EMPTY_LINE_REGEX.match(line):
@@ -97,6 +112,7 @@ class TestStashcache:
             else:
                 assert False, 'Unexpected text "%s".\nFull text:\n%s' % (line, nohost_text)
 
+        m = mocker.patch.object(global_data, "get_ligo_dn_list", spec={"return_value": MOCK_DN_LIST})
         test_cache_text = stashcache.generate_cache_grid_mapfile(global_data,
                                                                  I2_TEST_CACHE,
                                                                  legacy=True,

--- a/src/tests/test_stashcache.py
+++ b/src/tests/test_stashcache.py
@@ -1,5 +1,6 @@
 import flask
 import pytest
+import re
 from pytest_mock import MockerFixture
 
 # Rewrites the path so the app can be imported like it normally is
@@ -10,6 +11,14 @@ sys.path.append(topdir)
 
 from app import app, global_data
 import stashcache
+
+GRID_MAPPING_REGEX = re.compile(r'^"/[^"]*CN=[^"]+"\s+[0-9a-f]{8}[.]0$')
+# ^^ the DN starts with a slash and will at least have a CN in it.
+EMPTY_LINE_REGEX = re.compile(r'^\s*(#|$)')  # Empty or comment-only lines
+I2_TEST_CACHE = "osg-sunnyvale-stashcache.t2.ucsd.edu"
+
+
+# ^^ one of the Internet2 caches; these serve both public and LIGO data
 
 @pytest.fixture
 def client():
@@ -42,6 +51,42 @@ class TestStashcache:
 
     def test_None_fdqn_isnt_error(self, client: flask.Flask):
         stashcache.generate_cache_authfile(global_data, None)
+
+    def test_origin_grid_mapfile(self, client: flask.Flask):
+        nohost_text = stashcache.generate_origin_grid_mapfile(global_data, "", suppress_errors=False)
+        for line in nohost_text.split("\n"):
+            assert EMPTY_LINE_REGEX.match(line)
+
+        test_origin_text = stashcache.generate_origin_grid_mapfile(global_data, "origin-auth2001.chtc.wisc.edu",
+                                                                   suppress_errors=False)
+        num_mappings = 0
+        for line in test_origin_text.split("\n"):
+            if EMPTY_LINE_REGEX.match(line):
+                continue
+            elif GRID_MAPPING_REGEX.match(line):
+                num_mappings += 1
+            else:
+                assert False, 'Unexpected text "%s".\nFull text:\n%s' % (line, test_origin_text)
+        assert num_mappings > 5, "Too few mappings found.\nFull text:\n%s" % test_origin_text
+
+    def test_cache_grid_mapfile(self, client: flask.Flask):
+        nohost_text = stashcache.generate_cache_grid_mapfile(global_data, "", legacy=False, suppress_errors=False)
+        for line in nohost_text.split("\n"):
+            assert EMPTY_LINE_REGEX.match(line), 'Unexpected text "%s".\nFull text:\n%s' % (line, nohost_text)
+
+        test_cache_text = stashcache.generate_cache_grid_mapfile(global_data,
+                                                                 I2_TEST_CACHE,
+                                                                 legacy=True,
+                                                                 suppress_errors=False)
+        num_mappings = 0
+        for line in test_cache_text.split("\n"):
+            if EMPTY_LINE_REGEX.match(line):
+                continue
+            elif GRID_MAPPING_REGEX.match(line):
+                num_mappings += 1
+            else:
+                assert False, 'Unexpected text "%s".\nFull text:\n%s' % (line, test_cache_text)
+        assert num_mappings > 5, "Too few mappings found.\nFull text:\n%s" % test_cache_text
 
 
 if __name__ == '__main__':

--- a/src/webapp/vos_data.py
+++ b/src/webapp/vos_data.py
@@ -285,6 +285,7 @@ class AuthMethod:
     is_public = False
     used_in_authfile = False
     used_in_scitokens_conf = False
+    used_in_grid_mapfile = False
 
     def get_authfile_id(self):
         return ""
@@ -292,6 +293,8 @@ class AuthMethod:
     def get_scitokens_conf_block(self, service_name: str):
         return ""
 
+    def get_grid_mapfile_line(self):
+        return ""
 
 class NullAuth(AuthMethod):
     pass
@@ -310,6 +313,7 @@ class PublicAuth(AuthMethod):
 
 class DNAuth(AuthMethod):
     used_in_authfile = True
+    used_in_grid_mapfile = True
 
     def __init__(self, dn: str):
         self.dn = dn
@@ -323,6 +327,8 @@ class DNAuth(AuthMethod):
     def get_authfile_id(self):
         return f"u {self.get_dn_hash()}"
 
+    def get_grid_mapfile_line(self):
+        return f'"{self.dn}" {self.get_dn_hash()}'
 
 class FQANAuth(AuthMethod):
     used_in_authfile = True


### PR DESCRIPTION
- add unique resource ID check (SOFTWARE-5068)
- add unique resource group ID check (SOFTWARE-5068)
- fix rg key name
- bump duplicate GroupIDs (SOFTWARE-5068)
- fix horrific 'ID :' syntax (SOFTWARE-5068)
- bump duplicate, non-WLCG Resource IDs (SOFTWARE-5068)
- fixup a couple more duplicate resource ids (SOFTWARE-5068)
- Create CMB_Petravick.yaml
- Update CMB_Petravick.yaml
- Update OSG.yaml
- Update LIGO.yaml
- Rename CMB_Petravick.yaml to Illinois_Petravick.yaml
- Update SDSC-NRP.yaml
- Update OSG.yaml
- Update SDSC-NRP.yaml
- Fix typo in SDSC_NRP_OSDF_ORIGIN name
- new arkansas at little rock project
- Bump duplicate IDs
- adding gateway development project for hieu at rowan
- new cert
- Add CMB_Petravick symlink
- Update SPRACE_downtime.yaml
- Update SPRACE_downtime.yaml
- Update AMNH_downtime.yaml
- Create SITE.yaml
- Update UFlorida-HPC_downtime.yaml
- Remove Inactive Sites from Map Display
- Remove the SWT2 gk10
- Update topology/University of Utah/Utah-SCI-VDC1/SITE.yaml
- Update topology/University of Utah/Utah-SCI-VDC1/SITE.yaml
- Update SCI Site Directory
- Delete topology/University of Utah/Utah-SCI-VDC1 directory
- Fix spacing
- Add resource group for SCI VDC Origin
- Add resource group and resource IDs
- Fix spacing
- Schedule planned downtime for T2_US_Vanderbilt
- Map Updates
- Create Eureka_Danehkar.yaml
- name change
- Update vanderbilt downtime
- Fix spacing
- Update UFlorida-HPC_downtime.yaml
- Appease the Topology checks
- Update IceCube.yaml
- Map Updates
- Update UFlorida-HPC_downtime.yaml
- Added suds-nrp-osdf-origin to OASIS
- Fix ip address of sam_uri for one CE.
- adding new iowa project
- Map Updates
- Update the Resource Group XML Schema
- Adding Doane university for GP-ARGO
- Creating FIU OSDF cache
- Update UFlorida-HPC_downtime.yaml
- Updated sdsc-nrp-osdf-origin url
- Add IDs
- adding caches
- Updating DN
- Update Site.yaml
- Update Site.yaml
- Update I2BoiseInfrastructure.yaml
- Update I2CincinnatiInfrastructure.yaml
- Rename Site.yaml to SITE.yaml
- Rename Site.yaml to SITE.yaml
- Update host certificate DN for Virgo origin. Add DN for ET origin.
- Update UFlorida-HPC.yaml
- Update UFlorida-HPC_downtime.yaml
- [CIT_CMS_T2] Scheduled downtime to move to OSG 3.6
- Update UHIFA.yaml
- add new ksu-beocat-ce1 hosted CE
- update USF_SC contact
- Add StashCache service description
- add resource ID
- Update PSU-LIGO.yaml
- allow ANY VO for ComputeCanada-Cedar-Cache
- Update I2BoiseInfrastructure.yaml
- Update I2CincinnatiInfrastructure.yaml
- Update UFlorida-HPC_downtime.yaml
- Update topology/Penn State University/PSU LIGO/PSU-LIGO.yaml
- bump resource ID
- Allow submitting to frontera from login04 for TG-CHE200122 as an alternative to xd-submit.chtc.wisc.edu
- Adding Jan 24 2023 downtime
- Update LIGO.yaml
- Add simple Prometheus update metrics
- Revert "Add simple Prometheus update metrics"
- Georgia Tech PACE OSG 2 Jan 2023 Maintenance Downtime
- adding new university of nevada folks
- Add NSHE -> Nevada System of Higher Education mapping (#2902)
- Update KISTIPRPCachingInfrastructure.yaml
- skip project symlinks when scanning for org names
- Update LIGO.yaml
- Update Gluex.yaml
- Update ComputeCanada-Cedar.yaml
- Create AmsterdamPRPCachingInfrastructure_downtime.yaml
- Update NCSA-DES.yaml
- Register the PATh Facility OSDF origin (INF-639)
- Allow writeback (INF-639)
- Allow dir listing (INF-639)
- Fix hostname of ComputeCanada-Cedar-Cache
- Address missed bytes -> str conversion
- Drop the unused 'family' var
- Activate TIGER-OSG-BACKFILL-ITB
- Security team GPG key is for @opensciencegrid.org (SOFTWARE-5455)
- Create SITE.yaml
- Add Kent State Research site ID
- Update AmsterdamPRPCachingInfrastructure_downtime.yaml
- Create SITE.yaml
- Update OSG.yaml
- Add downtime for USCMS-FNAL-WC1-SE due to FTS server swap-back
- Add Kent State University Facility ID (FD#71868)
- Update PATh origin FQDN (INF-639)
- Update OSG.yaml
- [CIT_CMS_T2] Migration done to 3.6
- Add ID
- Add FACILITY.yaml to "University of Massachusetts - Amherst"
- Allow PATh issuer access to /ospool/PROTECTED (INF-406)
- Make sure the base paths match for a given issuer (INF-406)
- Fix Writeback + DirList to match the new FQDN (INF-406)
- Update AMNH_downtime.yaml
- Fix scitokens.conf for the PATh Facility origin (INF-406)
- Replace redundant "path" in the PF origin FQDN (INF-639)
- Move end of GT OSG PACE 2 downtime earlier
- Issuer should not have a trailing slash (INF-406)
- Extending the downtime for one of the CEs
- Register CHTC-ITB-GPU-EP so I can make a GPU container on Tiger that I can test container universe GPU support on
- Don't tag it OSPool; it's in the ITB pool
- Create INFN-T1CachingInfrastructure_downtime.yaml
- Create ComputeCanada-Cedar_downtime.yaml
- Add stub endpoint and test for generating a grid-mapfile for an origin (SOFTWARE-5466)
